### PR TITLE
Loosen bounds on `base` to compile against GHC 9

### DIFF
--- a/hasql-explain-tests.cabal
+++ b/hasql-explain-tests.cabal
@@ -28,7 +28,7 @@ library
       ImportQualifiedPost
       LambdaCase
       OverloadedStrings
-    build-depends:    base ^>=4.14.3.0,
+    build-depends:    base >=4.14.3.0 && <5,
                       bytestring <1,
                       hasql >= 1.0,
                       tmp-postgres >= 1.34,
@@ -45,7 +45,7 @@ test-suite hasql-explain-tests-simple
     main-is:          simple.hs
     default-extensions:
       OverloadedStrings
-    build-depends:    base ^>=4.14.3.0,
+    build-depends:    base >=4.14.3.0 && <5,
                       hasql-explain-tests,
                       tasty, 
                       tasty-hunit,


### PR DESCRIPTION
Hi there, and thanks for this library!

I recently performed a migration of a large codebase to GHC 9, which required vendoring this library with a patched cabal file for this library to accept a newer version of `base`.

Would you be happy to accept this patch and bump it on hackage?